### PR TITLE
prevent character to Date dates comparison on R 4.1 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ BugReports: https://github.com/Robinlovelace/spanishoddata/issues
 Depends:
     R (>= 3.5.0)
 Imports: 
-    curl,
+    curl (>= 5.0.0),
     DBI,
     dplyr,
     duckdb,

--- a/R/convert_data.R
+++ b/R/convert_data.R
@@ -48,6 +48,7 @@ spod_convert <- function(
     message("No period specified in the `dates` argument. Please set `dates='cached_v1'` or `dates='cached_v2'` to convert all data that was previously downloaded. Alternatively, specify at least one date between 2020-02-14 and 2021-05-09 (for v1 data) or between 2022-01-01 onwards (for v2). Any missing data will be downloaded before conversion.")
   }
 
+  spod_dates_argument_to_dates_seq(dates = dates)
   ver <- spod_infer_data_v_from_dates(dates)
   
   # check if user is requesting to just get all cached data

--- a/R/get_v1_data.R
+++ b/R/get_v1_data.R
@@ -460,20 +460,21 @@ spod_get <- function(
     message("No period specified in the `dates` argument. Please set `dates='cached_v1'` or `dates='cached_v2'` to convert all data that was previously downloaded. Alternatively, specify at least one date between 2020-02-14 and 2021-05-09 (for v1 data) or between 2022-01-01 onwards (for v2). Any missing data will be downloaded before conversion.")
   }
   
-  ver <- spod_infer_data_v_from_dates(dates)
   
   type <- match.arg(type)
   type <- spod_match_data_type(type = type)
-
+  
   zones <- match.arg(zones)
   zones <- spod_zone_names_en2es(zones)
-
+  
   # check if user is requesting to just get all cached data
   cached_data_requested <- length(dates) == 1 &&
     all(as.character(dates) %in% c("cached_v1", "cached_v2"))
   
+  
   if (isFALSE(cached_data_requested)) {
     dates <- spod_dates_argument_to_dates_seq(dates = dates)
+    ver <- spod_infer_data_v_from_dates(dates)
     # use the spot_download_data() function to download any missing data
     spod_download_data(
       type = type,
@@ -483,9 +484,11 @@ spod_get <- function(
       data_dir = data_dir,
       return_output = FALSE
     )
+  } else if (isTRUE(cached_data_requested)) {
+    ver <- as.numeric(stringr::str_extract(dates, "(1|2)$"))
   }
-
-
+  
+  
   # create in memory duckdb connection
   drv <- duckdb::duckdb()
   con <- DBI::dbConnect(drv, dbdir = duckdb_target, read_only = FALSE)

--- a/R/internal_utils.R
+++ b/R/internal_utils.R
@@ -27,6 +27,9 @@ spod_dates_argument_to_dates_seq <- function(dates) {
   if (is.null(dates) || (!is.character(dates) && !inherits(dates, "Date"))) {
     stop("Invalid date input format. Please provide a character vector or Date object.")
   }
+  if (length(dates) == 1 && dates %in% c("cached_v1", "cached_v2")) {
+    return(dates)
+  }
 
   range_regex <- "^\\d{4}(-\\d{2}){2}_\\d{4}(-\\d{2}){2}$|^\\d{8}_\\d{8}$"
   single_date_regex <- "^(\\d{4}-\\d{2}-\\d{2}|\\d{8})$"


### PR DESCRIPTION
Fix #71 , #72 .

#71 was apparently because starting with some R version, R was ok to compare the strings with dates automagically. Introduced some safeguards against that.