### PR TITLE
Fix missing library

### DIFF
--- a/vignettes/quick-get.qmd
+++ b/vignettes/quick-get.qmd
@@ -26,6 +26,7 @@ Make sure you have loaded the package:
 ```{r}
 library(spanishoddata)
 library(dplyr)
+library(stringr)
 ```
 
 


### PR DESCRIPTION
Missing library declaration for {stringr} because the script is using the str_detect function.