### PR TITLE
remove max cpu cores check

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -45,7 +45,7 @@ spod_connect <- function(
   checkmate::assert_character(target_table_name, null.ok = TRUE)
   checkmate::assert_flag(quiet)
   checkmate::assert_number(max_mem_gb, lower = 1)
-  checkmate::assert_integerish(max_n_cpu, lower = 1, upper = parallelly::availableCores())
+  checkmate::assert_integerish(max_n_cpu, lower = 1)
   checkmate::assert_directory_exists(temp_path, access = "rw")
 
   # determine if data_path is a folder or a duckdb file

--- a/R/convert.R
+++ b/R/convert.R
@@ -79,7 +79,7 @@ spod_convert <- function(
   checkmate::assert_directory_exists(data_dir, access = "rw")
   checkmate::assert_flag(quiet)
   checkmate::assert_number(max_mem_gb, lower = 0.1)
-  checkmate::assert_integerish(max_n_cpu, lower = 1, upper = parallelly::availableCores())
+  checkmate::assert_integerish(max_n_cpu, lower = 1)
   checkmate::assert_number(max_download_size_gb, lower = 0.1)
   checkmate::assert_flag(ignore_missing_dates)
 

--- a/R/get.R
+++ b/R/get.R
@@ -63,7 +63,7 @@ spod_get <- function(
   ))
   checkmate::assert_flag(quiet)
   checkmate::assert_number(max_mem_gb, lower = 1)
-  checkmate::assert_integerish(max_n_cpu, lower = 1, upper = parallelly::availableCores())
+  checkmate::assert_integerish(max_n_cpu, lower = 1)
   checkmate::assert_number(max_download_size_gb, lower = 0.1)
   checkmate::assert_string(duckdb_target)
   checkmate::assert_directory_exists(data_dir, access = "rw")

--- a/tests/testthat/test-quick-get.R
+++ b/tests/testthat/test-quick-get.R
@@ -31,7 +31,7 @@ test_that("spod_quick_get_od fails on incorrect distances", {
 test_that("spod_quick_get_od fails on negative min_trips", {
   expect_error(
     spod_quick_get_od(
-      date = "2022-01-01",
+      date = "2022-01-02",
       min_trips = -1
     ),
     ".*Assertion.*failed.*"
@@ -41,7 +41,7 @@ test_that("spod_quick_get_od fails on negative min_trips", {
 test_that("spod_quick_get_od fails on invalid municipality IDs", {
   expect_error(
     spod_quick_get_od(
-      date = "2022-01-01",
+      date = "2022-01-03",
       id_origin = "invalid"
     ),
     ".*Invalid municipality IDs detected.*"
@@ -49,7 +49,7 @@ test_that("spod_quick_get_od fails on invalid municipality IDs", {
   
   expect_error(
     spod_quick_get_od(
-      date = "2022-01-01",
+      date = "2022-01-04",
       id_destination = "invalid"
     ),
     ".*Invalid municipality IDs detected.*"
@@ -57,7 +57,7 @@ test_that("spod_quick_get_od fails on invalid municipality IDs", {
   
   expect_error(
     spod_quick_get_od(
-      date = "2022-01-01",
+      date = "2022-01-05",
       id_origin = "invalid",
       id_destination = "invalid"
     ),


### PR DESCRIPTION
Only keep the minimum, as 0 or negative cores will cause the functions to fail, as the underlying duckdb will fail.