### PR TITLE
Inject Google Search Console verification tag during website build

### DIFF
--- a/.github/workflows/rostemplate-gh-pages.yaml
+++ b/.github/workflows/rostemplate-gh-pages.yaml
@@ -32,6 +32,11 @@ jobs:
             ropenspain/rostemplate
           needs: website
 
+      - name: Create Google Search Console verification file
+        run: |
+          mkdir -p pkgdown/assets
+          echo -n "google-site-verification: google791d291f91311a84.html" > pkgdown/assets/google791d291f91311a84.html
+
       - name: Deploy package
         run: |
           git config --local user.name "github-actions[bot]"


### PR DESCRIPTION
@Robinlovelace @eugenividal heads up, this website code injection is for me to view google's search stats in search console. This does not install any tracking on the website itself, this is just for Google Search Console to verify that I am the website owner.